### PR TITLE
Move from open9 to hotspot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           file: Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
-            URL=https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09_openj9-0.20.0/OpenJDK8U-jdk_x64_linux_openj9_linuxXL_8u252b09_openj9-0.20.0.tar.gz
+            URL=ttps://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u282b08.tar.gz
           tags: |
             ctxsh/java:jdk8
 
@@ -35,7 +35,7 @@ jobs:
           file: Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
-            URL=https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09_openj9-0.20.0/OpenJDK8U-jre_x64_linux_openj9_linuxXL_8u252b09_openj9-0.20.0.tar.gz
+            URL=https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_x64_linux_hotspot_8u282b08.tar.gz
           tags:
             ctxsh/java:jre8
 
@@ -46,7 +46,7 @@ jobs:
           file: Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
-            URL=https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10_openj9-0.20.0/OpenJDK11U-jdk_x64_linux_openj9_linuxXL_11.0.7_10_openj9-0.20.0.tar.gz
+            URL=https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz
           tags: |
             ctxsh/java:jdk11
 
@@ -57,7 +57,7 @@ jobs:
           file: Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
-            URL=https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10_openj9-0.20.0/OpenJDK11U-jre_x64_linux_openj9_linuxXL_11.0.7_10_openj9-0.20.0.tar.gz
+            URL=https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_x64_linux_hotspot_11.0.10_9.tar.gz
           tags:
             ctxsh/java:jre11
 
@@ -68,7 +68,7 @@ jobs:
           file: Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
-            URL=https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7_openj9-0.20.0/OpenJDK14U-jdk_x64_linux_openj9_linuxXL_14.0.1_7_openj9-0.20.0.tar.gz
+            URL=https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz
           tags: |
             ctxsh/java:jdk14
 
@@ -79,6 +79,6 @@ jobs:
           file: Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
-            URL=https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7_openj9-0.20.0/OpenJDK14U-jre_x64_linux_openj9_linuxXL_14.0.1_7_openj9-0.20.0.tar.gz
+            URL=https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_x64_linux_hotspot_14.0.2_12.tar.gz
           tags:
             ctxsh/java:jre14

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ java: jdk8 jre8 jdk11 jre11 jdk14 jre14
 .PHONY: jdk8
 jdk8:
 	@docker build \
-		--build-arg "URL=https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09_openj9-0.20.0/OpenJDK8U-jdk_x64_linux_openj9_linuxXL_8u252b09_openj9-0.20.0.tar.gz" \
+		--build-arg "URL=https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u282b08.tar.gz" \
 		--tag $(DOCKERHUB_USER)/java:jdk8 \
 		--file Dockerfile \
 		.
@@ -26,7 +26,7 @@ jdk8:
 .PHONY: jre8
 jre8:
 	@docker build \
-		--build-arg "URL=https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09_openj9-0.20.0/OpenJDK8U-jre_x64_linux_openj9_linuxXL_8u252b09_openj9-0.20.0.tar.gz" \
+		--build-arg "URL=https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_x64_linux_hotspot_8u282b08.tar.gz" \
 		--tag $(DOCKERHUB_USER)/java:jre8 \
 		--file Dockerfile \
 		.
@@ -34,7 +34,7 @@ jre8:
 .PHONY: jdk11
 jdk11:
 	@docker build \
-		--build-arg "URL=https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_x64_linux_openj9_linuxXL_11.0.10_9_openj9-0.24.0.tar.gz" \
+		--build-arg "URL=https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz" \
 		--tag $(DOCKERHUB_USER)/java:jdk11 \
 		--file Dockerfile \
 		.
@@ -42,7 +42,7 @@ jdk11:
 .PHONY: jre11
 jre11:
 	@docker build \
-		--build-arg "URL=https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_x64_linux_openj9_linuxXL_11.0.10_9_openj9-0.24.0.tar.gz" \
+		--build-arg "URL=https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_x64_linux_hotspot_11.0.10_9.tar.gz" \
 		--tag $(DOCKERHUB_USER)/java:jre11 \
 		--file Dockerfile \
 		.
@@ -50,7 +50,7 @@ jre11:
 .PHONY: jdk14
 jdk14:
 	@docker build \
-		--build-arg "URL=https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_x64_linux_openj9_linuxXL_14.0.2_12_openj9-0.21.0.tar.gz" \
+		--build-arg "URL=https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz" \
 		--tag $(DOCKERHUB_USER)/java:jdk14 \
 		--file Dockerfile \
 		.
@@ -58,7 +58,7 @@ jdk14:
 .PHONY: jre14
 jre14:
 	@docker build \
-		--build-arg "URL=https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_x64_linux_openj9_linuxXL_14.0.2_12_openj9-0.21.0.tar.gz" \
+		--build-arg "URL=https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_x64_linux_hotspot_14.0.2_12.tar.gz" \
 		--tag $(DOCKERHUB_USER)/java:jre14 \
 		--file Dockerfile \
 		.


### PR DESCRIPTION
Open9 has had a few quirks so move to hotspot for the long term.  Might re-evaluate later.